### PR TITLE
`Incomplete`-ness bug

### DIFF
--- a/core/avaleryar.cabal
+++ b/core/avaleryar.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cb24277ec76c8c58096fc0d964c9fa279bec7d2a2f1b4944c8ff815dc16d86a9
+-- hash: 303ca43cd2b62bd8d25be353c47a11a9a00b4aa4d8394dac6cf5fe38bb1d4f3b
 
 name:           avaleryar
-version:        0.0.0
+version:        0.0.1
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -1,5 +1,5 @@
 name: avaleryar
-
+version: 0.0.1
 
 library:
   source-dirs: src

--- a/core/src/Control/Monad/FBackTrackT.hs
+++ b/core/src/Control/Monad/FBackTrackT.hs
@@ -80,7 +80,7 @@ instance Monad m => MonadPlus (Stream m) where
         One b        -> return $ Choice b i
         Choice b r'  -> return $ Choice b (mplus i r')
         -- Choice _ _ -> Incomplete (mplus r' i)
-        Incomplete j -> return $ Incomplete (mplus i j)
+        Incomplete j -> return . Incomplete . yield $ mplus i j
 
 instance Monad m => Fail.MonadFail (Stream m) where
   fail _ = mzero

--- a/core/test/SemanticsSpec.hs
+++ b/core/test/SemanticsSpec.hs
@@ -17,22 +17,21 @@ import Test.Hspec
 spec :: Spec
 spec = do
   describe "infinite loops" $ do
-    it "don't run forever" $ do
-      let go = runAvalaryarT 5000 1 testDb q
-          q  = compileQuery "system" "loop" [Var "x"]
-      timeoutSecs 1 go `shouldReturn` Just []
+    it "don't run forever on a simple loop" $ do
+      shouldNotTimeout $ queryFile (exampleFile "loops.ava") [qry| loop1(?z) |]
+
+    it "don't run forever on a less simple loop" $ do
+      shouldNotTimeout $ queryFile (exampleFile "loops.ava") [qry| loop2(?z) |]
 
     it "have limited output" $ do
       Just answers <- timeoutSecs 1 $ runAvalaryarT 5000 10 testDb (msum . replicate 74 $ pure ())
       length answers `shouldBe` 10
 
     it "demonstrate fair conjunction" $ do
-      answers <- queryFile (exampleFile "fair-conjunction.ava") [qry| a(?x) |]
-      answers `shouldNotSatisfy` null
+      shouldSucceed $ queryFile (exampleFile "fair-conjunction.ava") [qry| a(?x) |]
 
     it "demonstrate fair disjunction" $ do
-      answers <- queryFile (exampleFile "fair-disjunction.ava") [qry| a(?x) |]
-      answers `shouldNotSatisfy` null
+      shouldSucceed $ queryFile (exampleFile "fair-disjunction.ava") [qry| a(?x) |]
 
     -- TODO: This is slow for some reason, to the tune of 2 seconds in ghcid
     it "finds paths" $ do
@@ -86,10 +85,10 @@ spec = do
                                  [rls| palindrome(?x) :- :prim says rev(?x, ?x). |]
 
     it "turns lists into multiple successes" $ do
-      answers <- queryRules [qry| bar(?rows) |]
-                           [rls| foo("a\nb\nc").
-                                 bar(?rows) :- foo(?text),
-                                 :prim says lines(?text, ?rows). |]
+      Success answers <- queryRules [qry| bar(?rows) |]
+                                   [rls| foo("a\nb\nc").
+                                         bar(?rows) :- foo(?text),
+                                         :prim says lines(?text, ?rows). |]
       answers `shouldMatchList` [ Lit (Pred "bar" 1) [Val "a"]
                                 , Lit (Pred "bar" 1) [Val "b"]
                                 , Lit (Pred "bar" 1) [Val "c"] ]
@@ -102,7 +101,7 @@ spec = do
 
 
     it "works on all the things (Int -> IO [(Int, Bool)])" $ do
-      answers <- queryRules [qry| go(?b, ?x, 5) |]
-                           [rls| go(?b, ?x, ?n) :- :prim says silly(?n, ?x, ?b). |]
+      Success answers <- queryRules [qry| go(?b, ?x, 5) |]
+                                   [rls| go(?b, ?x, ?n) :- :prim says silly(?n, ?x, ?b). |]
       length answers `shouldBe` 5
 

--- a/core/test/examples/loops.ava
+++ b/core/test/examples/loops.ava
@@ -1,0 +1,5 @@
+
+loop1(?x) :- loop1(?x).
+
+loop2(?x) :- loop2(?x).
+loop2(?y) :- loop2(?y).

--- a/extras/avaleryar-extras.cabal
+++ b/extras/avaleryar-extras.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b18813f29a93ff09160b6c722f0c7614f312a948f94ca76fcb547573b6d18d2c
+-- hash: c34fefab011b8b7b41eb151f3d14c93938504336118a3e86ece1c64448e2a9b6
 
 name:           avaleryar-extras
-version:        0.0.0
+version:        0.0.1
 build-type:     Simple
 
 library

--- a/extras/package.yaml
+++ b/extras/package.yaml
@@ -1,5 +1,5 @@
 name: avaleryar-extras
-
+version: 0.0.1
 
 library:
   source-dirs: src

--- a/repl/avaleryar-repl.cabal
+++ b/repl/avaleryar-repl.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2b3eb8bc7ce55b1eac3a9fdc1ed2f248c6c878c21163ca0eff204e23fc584359
+-- hash: 5d68008389432e95ca6541147a5c559b2ab1b9a1fce446410dfa24f631faf411
 
 name:           avaleryar-repl
-version:        0.0.0
+version:        0.0.1
 build-type:     Simple
 
 library

--- a/repl/package.yaml
+++ b/repl/package.yaml
@@ -1,4 +1,5 @@
 name: avaleryar-repl
+version: 0.0.1
 
 library:
   source-dirs: src


### PR DESCRIPTION
This fixes a bug where a tight loop caused some nontrivial slowdown---specifically, it caused:

```
a(?x) :- a(?x).
a(?y) :- a(?y).
```

to run effectively forever by not decrementing the fuel counter promptly enough.  We had a test for:

```
a(?x) :- a(?x).
```

already, but that doesn't evince the bug, which effectively amounted to doubling the amount of work in between each backtrack out of `a/1`.  This behaves linearly in the second case, but exponentially in the first.  Which was bad.

Pretty much all credit for finding the bug, reducing it to a minimal case, and seeing the solution goes to @shterrett.