### PR TITLE
provide fuel consumption from query results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ timestamps {
                          /* Build haskell binaries */
                          sh '''
                              # no -Werror until ghc 8.8 is on everywhere
-                             stack test avaleryar avaleryar-extras avaleryar-repl --ghc-options='-Wall' --fast
+                             stack test avaleryar avaleryar-repl --ghc-options='-Wall' --fast
                          '''
                         }
                     }

--- a/core/src/Language/Avaleryar/PDP/Handle.hs
+++ b/core/src/Language/Avaleryar/PDP/Handle.hs
@@ -52,8 +52,11 @@ submitText h assn text facts = modifyWithPDPHandle h $ PDP.submitText assn text 
 unsafeSubmitText :: PDPHandle -> Text -> Text -> IO (Either PDPError ())
 unsafeSubmitText h assn text = modifyWithPDPHandle h $ PDP.unsafeSubmitText assn text
 
-runQuery :: PDPHandle -> [Fact] -> Text -> [Term TextVar] -> IO (Either PDPError [Fact])
+runQuery :: PDPHandle -> [Fact] -> Text -> [Term TextVar] -> IO (Either PDPError QueryResults)
 runQuery h facts p args = withPDPHandle h $ PDP.runQuery facts p args
+
+runDetailedQuery :: PDPHandle -> [Fact] -> Text -> [Term TextVar] -> IO (Either PDPError DetailedQueryResults)
+runDetailedQuery h facts p args = withPDPHandle h $ PDP.runDetailedQuery facts p args
 
 checkQuery :: PDPHandle -> [Fact] -> Text -> [Term TextVar] -> IO (Either PDPError Bool)
 checkQuery h facts p args = runQuery h facts p args >>= pure . fmap (not . null)

--- a/core/src/Language/Avaleryar/PrettyPrinter.hs
+++ b/core/src/Language/Avaleryar/PrettyPrinter.hs
@@ -50,7 +50,7 @@ instance Pretty RawVar where
 putQuery :: Lit TextVar -> IO ()
 putQuery = putDoc . pretty
 
-putFacts :: [Fact] -> IO ()
+putFacts :: Foldable t => t Fact -> IO ()
 putFacts = traverse_ (putDoc . pretty . factToRule @TextVar)
 
 putRulesDb :: RulesDb m -> IO ()

--- a/core/src/Language/Avaleryar/Testing.hs
+++ b/core/src/Language/Avaleryar/Testing.hs
@@ -21,7 +21,7 @@
 --     coexist in a file and yet more or less ignoring the rules that appear in "test files", so to
 --     speak.
 --
---   * Something isn't quite right about the whole 'TestResults' and 'putResults' stack.
+--   * Something isn't quite right about the whole 'TestResults' and 'putTestResults' stack.
 --
 --   * We don't aggregate test results---would be nice to do percentages and make it more obvious
 --     when one amongst a large pile of tests has failed for better UX.
@@ -47,8 +47,8 @@ module Language.Avaleryar.Testing
   , runTestFile
   , withTestHandle
   , withTestHandle_
-  , prettyResults
-  , putResults
+  , prettyTestResults
+  , putTestResults
   ) where
 
 import           Data.Bool                    (bool)
@@ -140,13 +140,13 @@ instance Pretty TestResult where
 instance Pretty TestError where
   pretty (MissingAssertions as) = "assertions missing: " <> (hsep . punctuate "," $ fmap pretty as)
 
-prettyResults :: Text -> TestResults -> Doc
-prettyResults tn rs = pretty tn <> nest 2 prs
+prettyTestResults :: Text -> TestResults -> Doc
+prettyTestResults tn rs = pretty tn <> nest 2 prs
   where prs       = either pretty ((line<>) . vsep . fmap pr) $ rs
         pr (q, r) = fillBreak 30 (pretty q <> colon) <+> pretty r
 
-putResults :: Text -> TestResults -> IO ()
-putResults tn rs = putDoc $ prettyResults tn rs <> line
+putTestResults :: Text -> TestResults -> IO ()
+putTestResults tn rs = putDoc $ prettyTestResults tn rs <> line
 
 runTest :: PDPHandle -> Test IO -> IO TestResults
 runTest hdl t = go (missingAssertions t)

--- a/core/src/Language/Avaleryar/Testing.hs
+++ b/core/src/Language/Avaleryar/Testing.hs
@@ -124,7 +124,7 @@ missingAssertions (Test tc (rs, ndb)) = unalias . filter (`notElem` assns) $ (fs
         unalias = foldMap (toList . flip lookup (testAssns tc))
 
 -- TODO: Pretty output for test results.
-data TestResult = Success | Failure | Error PDPError
+data TestResult = Pass | Fail | Error PDPError
   deriving (Eq, Ord, Show)
 
 data TestError = MissingAssertions [Text]
@@ -133,8 +133,8 @@ data TestError = MissingAssertions [Text]
 type TestResults = Either TestError [(Query, TestResult)]
 
 instance Pretty TestResult where
-  pretty Success   = "ok"
-  pretty Failure   = "fail"
+  pretty Pass      = "ok"
+  pretty Fail      = "fail"
   pretty (Error e) = pretty $ show e -- TODO: Suck Less
 
 instance Pretty TestError where
@@ -156,7 +156,7 @@ runTest hdl t = go (missingAssertions t)
 
 runTestQuery :: PDPHandle -> [Fact] -> Query -> IO TestResult
 runTestQuery hdl app (Lit (Pred p _) as) = resultify <$> checkQuery hdl app p as
-  where resultify = either Error (bool Failure Success)
+  where resultify = either Error (bool Fail Pass)
 
 runTestQuery' :: PDPHandle -> [Fact] -> Query -> IO (Query, TestResult)
 runTestQuery' hdl app q = (q,) <$> runTestQuery hdl app q

--- a/core/test/SemanticsSpec.hs
+++ b/core/test/SemanticsSpec.hs
@@ -85,10 +85,10 @@ spec = do
                                  [rls| palindrome(?x) :- :prim says rev(?x, ?x). |]
 
     it "turns lists into multiple successes" $ do
-      Success answers <- queryRules [qry| bar(?rows) |]
-                                   [rls| foo("a\nb\nc").
-                                         bar(?rows) :- foo(?text),
-                                         :prim says lines(?text, ?rows). |]
+      Result (Success answers) <- queryRules [qry| bar(?rows) |]
+                                             [rls| foo("a\nb\nc").
+                                                   bar(?rows) :- foo(?text),
+                                                   :prim says lines(?text, ?rows). |]
       answers `shouldMatchList` [ Lit (Pred "bar" 1) [Val "a"]
                                 , Lit (Pred "bar" 1) [Val "b"]
                                 , Lit (Pred "bar" 1) [Val "c"] ]
@@ -101,7 +101,7 @@ spec = do
 
 
     it "works on all the things (Int -> IO [(Int, Bool)])" $ do
-      Success answers <- queryRules [qry| go(?b, ?x, 5) |]
-                                   [rls| go(?b, ?x, ?n) :- :prim says silly(?n, ?x, ?b). |]
+      Result (Success answers) <- queryRules [qry| go(?b, ?x, 5) |]
+                                             [rls| go(?b, ?x, ?n) :- :prim says silly(?n, ?x, ?b). |]
       length answers `shouldBe` 5
 

--- a/repl/avaleryar-repl.cabal
+++ b/repl/avaleryar-repl.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5d68008389432e95ca6541147a5c559b2ab1b9a1fce446410dfa24f631faf411
+-- hash: 49fcbd961da9eac0ec33322a1a445073676debb608f0dbd9ebf370c8f8e94a01
 
 name:           avaleryar-repl
 version:        0.0.1
@@ -19,7 +19,6 @@ library
       src
   build-depends:
       avaleryar
-    , avaleryar-extras
     , base
     , containers
     , haskeline

--- a/repl/package.yaml
+++ b/repl/package.yaml
@@ -6,7 +6,6 @@ library:
   dependencies:
     - base
     - avaleryar
-    - avaleryar-extras
 
     - containers
     - haskeline

--- a/repl/src/Language/Avaleryar/Repl.hs
+++ b/repl/src/Language/Avaleryar/Repl.hs
@@ -31,7 +31,7 @@ import Language.Avaleryar.PDP.Handle
 import Language.Avaleryar.PrettyPrinter
 import Language.Avaleryar.Semantics     (DetailedResults(..), DetailedQueryResults)
 import Language.Avaleryar.Syntax
-import Language.Avaleryar.Testing       (runTestFile, putResults, TestResults)
+import Language.Avaleryar.Testing       (runTestFile, putTestResults, TestResults)
 
 -- | Spin up a repl using the given 'PDPConfig', configuring its underlying 'PDPHandle' with a
 -- callback.
@@ -51,7 +51,7 @@ main = do
   Args {..}  <- execParser (info parseArgs mempty)
   Right conf <- pdpConfig demoNativeDb systemAssn
   let loadAssns h = for_ otherAssns $ either (error . show) pure <=< unsafeSubmitFile h Nothing
-      displayResults = traverse_ $ either putStrLn (traverse_ $ uncurry putResults)
+      displayResults = traverse_ $ either putStrLn (traverse_ $ uncurry putTestResults)
   if   null testFiles
   then replWithHandle conf loadAssns
   else runTestFiles conf loadAssns testFiles >>= displayResults

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 resolver: lts-15.5
 packages:
   - ./core
-  - ./extras
+  # - ./extras # avaleryar-extras isn't getting the use I'd hoped; gonna stop building it for a bit.
   - ./repl
 extra-deps:
   - qq-literals-0.1.0.1


### PR DESCRIPTION
Adds `AvaResults` and `DetailedResults` types that are produced respectively from `runAvaleryarT` and the new `runAvaleryarT'`, as well as outputting that information in the repl.  Feel free to have opinions about the ergonomics.