### PR TITLE
update Stack resolver to GHC 8.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .stack-work
-*.cabal
+dist-newstyle
 *.tix
 *.ava
 .history

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ timestamps {
                         dir(path: "${haskellWorkDir}/") {
                             def scmVars = checkout([
                                 $class: 'GitSCM',
-                                branches: [[ name: env.BRANCH_NAME ]],
+                                branches: [[ name: env.CHANGE_BRANCH ]],
                                 userRemoteConfigs: [[credentialsId: '010e0c41-651f-4f83-8706-b5f4281d9e9c', url: 'git@github.com:Simspace/avaleryar.git']],
                                 extensions: [[$class: 'CleanBeforeCheckout']],
                             ])

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,4 @@
+packages:
+  ./core
+  ./extras
+  ./repl

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
 packages:
   ./core
-  ./extras
+  -- ./extras -- see comment in stack.yaml
   ./repl

--- a/core/avaleryar.cabal
+++ b/core/avaleryar.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: a97ed2c9f1723a98756c0636259d71acc64ef8ce95ef5178958ddb540e50baf3
 
 name:           avaleryar
-version:        0.0.1
+version:        0.0.1.1
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -1,5 +1,5 @@
 name: avaleryar
-version: 0.0.1
+version: 0.0.1.1
 
 library:
   source-dirs: src

--- a/extras/package.yaml
+++ b/extras/package.yaml
@@ -1,5 +1,5 @@
 name: avaleryar-extras
-version: 0.0.1
+version: 0.0.1.1
 
 library:
   source-dirs: src

--- a/repl/avaleryar-repl.cabal
+++ b/repl/avaleryar-repl.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 49fcbd961da9eac0ec33322a1a445073676debb608f0dbd9ebf370c8f8e94a01
+-- hash: 7035551c001e4368c98bedebea9a85f4f2e861fb2078c96da206c369e932ded4
 
 name:           avaleryar-repl
 version:        0.0.1
@@ -21,7 +21,7 @@ library
       avaleryar
     , base
     , containers
-    , haskeline
+    , haskeline ==0.7.*
     , mtl
     , optparse-applicative
     , read-editor

--- a/repl/avaleryar-repl.cabal
+++ b/repl/avaleryar-repl.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7035551c001e4368c98bedebea9a85f4f2e861fb2078c96da206c369e932ded4
+-- hash: f93da3e2bc1b2c117fc823aa2162670a50c41b71dec41a50354a8da67861635c
 
 name:           avaleryar-repl
-version:        0.0.1
+version:        0.0.1.1
 build-type:     Simple
 
 library

--- a/repl/avaleryar-repl.cabal
+++ b/repl/avaleryar-repl.cabal
@@ -21,11 +21,11 @@ library
       avaleryar
     , base
     , containers
-    , haskeline ==0.7.*
+    , haskeline
     , mtl
     , optparse-applicative
     , read-editor
-    , repline
+    , repline ==0.3.*
     , text
     , wl-pprint-text
   default-language: Haskell2010

--- a/repl/package.yaml
+++ b/repl/package.yaml
@@ -8,7 +8,7 @@ library:
     - avaleryar
 
     - containers
-    - haskeline
+    - haskeline ==0.7.*
     - mtl
     - optparse-applicative
     - read-editor

--- a/repl/package.yaml
+++ b/repl/package.yaml
@@ -8,7 +8,7 @@ library:
     - avaleryar
 
     - containers
-    - haskeline ==0.7.*
+    - haskeline
     - mtl
     - optparse-applicative
     - read-editor

--- a/repl/package.yaml
+++ b/repl/package.yaml
@@ -1,5 +1,5 @@
 name: avaleryar-repl
-version: 0.0.1
+version: 0.0.1.1
 
 library:
   source-dirs: src

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.5
+resolver: lts-17.6
 packages:
   - ./core
   # - ./extras # avaleryar-extras isn't getting the use I'd hoped; gonna stop building it for a bit.
@@ -6,3 +6,4 @@ packages:
 extra-deps:
   - qq-literals-0.1.0.1
   - jsonpath-0.1.0.1
+  - repline-0.3.0.0


### PR DESCRIPTION
Both Stack and Cabal build with GHC 8.10 successfully:

```
% stack test --no-run-tests     
avaleryar> Test running disabled by --no-run-tests flag.

% ghc --version
The Glorious Glasgow Haskell Compilation System, version 8.10.4

% cabal build --enable-tests all
Up to date
```