### PR TITLE
Optimize facts

### DIFF
--- a/core/avaleryar.cabal
+++ b/core/avaleryar.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 30fac0c3b148d219353f8644d0c0934b9b681991e4892964c8bbf9aba9738fc7
+-- hash: f8cb069a0604c1962ead2433e06e9d15fe5c8b4130dd40019dfb22f3cd57183e
 
 name:           avaleryar
 version:        0.0.1.1
@@ -39,6 +39,7 @@ library
     , qq-literals
     , template-haskell
     , text
+    , vector
     , wl-pprint-text
   default-language: Haskell2010
 

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -16,6 +16,7 @@ library:
     - template-haskell
     - text
     - unordered-containers
+    - vector
     - wl-pprint-text
 
 tests:

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -15,6 +15,7 @@ library:
     - qq-literals
     - template-haskell
     - text
+    - unordered-containers
     - wl-pprint-text
 
 tests:

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -15,7 +15,6 @@ library:
     - qq-literals
     - template-haskell
     - text
-    - unordered-containers
     - vector
     - wl-pprint-text
 

--- a/core/src/Language/Avaleryar/Semantics.hs
+++ b/core/src/Language/Avaleryar/Semantics.hs
@@ -86,8 +86,8 @@ import Language.Avaleryar.Syntax
 -- | A native predicate carries not just its evaluation function, but also its signature, so it may
 -- be consulted when new assertions are submitted in order to mode-check them.
 data NativePred = NativePred
-  { nativePred :: Lit EVar -> Avaleryar ()
-  , nativeSig  :: ModedLit
+  { nativePred :: !(Lit EVar -> Avaleryar ())
+  , nativeSig  :: !ModedLit
   } deriving Generic
 
 instance NFData NativePred
@@ -109,8 +109,8 @@ instance NFData NativeDb
 
 -- TODO: newtype harder (newtype RuleAssertion c = ..., newtype NativeAssertion c = ...)
 data Db = Db
-  { rulesDb  :: RulesDb
-  , nativeDb :: NativeDb
+  { rulesDb  :: !RulesDb
+  , nativeDb :: !NativeDb
   } deriving (Generic)
 
 instance Semigroup Db where
@@ -135,9 +135,9 @@ loadNative n p = getsRT (unNativeDb . nativeDb . db) >>= alookup n >>= alookup p
 
 -- | Runtime state for 'Avaleryar' computations.
 data RT = RT
-  { env   :: Env   -- ^ The accumulated substitution
-  , epoch :: Epoch -- ^ A counter for generating fresh variables
-  , db    :: Db    -- ^ The database of compiled predicates
+  { env   :: !Env   -- ^ The accumulated substitution
+  , epoch :: !Epoch -- ^ A counter for generating fresh variables
+  , db    :: !Db    -- ^ The database of compiled predicates
   } deriving (Generic)
 
 -- | Allegedly more-detailed results from an 'Avaleryar' computation.  A more ergonomic type is

--- a/core/src/Language/Avaleryar/Semantics.hs
+++ b/core/src/Language/Avaleryar/Semantics.hs
@@ -72,7 +72,7 @@ import           Control.Monad.State
 import           Data.Foldable
 import           Data.Map                     (Map)
 import qualified Data.Map                     as Map
-import           Data.Maybe
+import           Data.Maybe                   (mapMaybe)
 import           Data.String
 import           Data.Vector                  (Vector)
 import qualified Data.Vector                  as Vector

--- a/core/src/Language/Avaleryar/Semantics.hs
+++ b/core/src/Language/Avaleryar/Semantics.hs
@@ -70,11 +70,12 @@ import           Control.DeepSeq              (NFData)
 import           Control.Monad.Except
 import           Control.Monad.State
 import           Data.Foldable
-import qualified Data.HashSet                 as HashSet
 import           Data.Map                     (Map)
 import qualified Data.Map                     as Map
 import           Data.Maybe
 import           Data.String
+import           Data.Vector                  (Vector)
+import qualified Data.Vector                  as Vector
 import           Data.Text                    (Text, pack)
 import           Data.Void                    (vacuous)
 import           GHC.Clock                    (getMonotonicTime)
@@ -282,7 +283,7 @@ compilePred rules =
   if all isFact rules
     then
       -- We precompute the set
-      let setOfVals = HashSet.fromList $ fmap (mapMaybe termVal . litTerms . ruleLit) rules
+      let setOfVals = Vector.fromList $ fmap (mapMaybe termVal . litTerms . ruleLit) rules
       in \arg@(Lit _ qas) -> do
         qas <- traverse subst qas
         let f term (allVals, vals) = case term of
@@ -293,7 +294,7 @@ compilePred rules =
         -- In that case, if the values of qas are in the set, the predicate succeeds.
         -- Otherwise, it fails.
         if allVals
-          then guard (HashSet.member vals setOfVals)
+          then guard (Vector.elem vals setOfVals)
           -- If qas aren't all values, we can't use the set and must fallback to the default behavior.
           -- This is because in this case the variables will be unified with the values, so it's not just
           -- a guard.

--- a/core/src/Language/Avaleryar/Semantics.hs
+++ b/core/src/Language/Avaleryar/Semantics.hs
@@ -273,31 +273,36 @@ compilePredDefault rules (Lit _ qas) = do
         traverse_ resolve body
   msum $ go <$> rules'
 
--- | NB: 'compilePred' doesn't look at the 'Pred' for any of the given rules, it assumes it was
--- given a query that applies, and that the rules it was handed are all for the same predicate.
--- This is not the function you want.
+-- | NB: 'compilePred' assumes it was given a query that applies, and that the
+-- rules it was handed are all for the same predicate. This is not the function
+-- you want.
 compilePred :: [Rule TextVar] -> Lit EVar -> Avaleryar ()
 compilePred rules =
-  -- If the rules are all facts, we can efficiently check
-  if (all isFact rules)
+  -- If the rules are all facts, unification may be done using a set in some common cases.
+  if all isFact rules
     then
+      -- We precompute the set
       let setOfVals = HashSet.fromList $ fmap (mapMaybe termVal . litTerms . ruleLit) rules
       in \arg@(Lit _ qas) -> do
         qas <- traverse subst qas
-        if HashSet.member (mapMaybe termVal qas) setOfVals
-          then pure ()
-          else
-            -- Maybe `qas` in not in the set of values because the terms are don't yet have values.
-            -- In that case, we revert to the default behavior.
-            -- Because we stop evaluating when we reach the first solution, that is only evaluated if necessary.
-            -- TODO: This can probably be optimized, but I can't think of a better and simplier way than that.
-            compilePredDefault rules arg
+        let f term (allVals, vals) = case term of
+                Val v -> (allVals, v:vals)
+                Var _ -> (False, vals)
+        let (allVals, vals) = foldr f (True, []) qas
+        -- This only works if the unification is being done between only values.
+        -- In that case, if the values of qas are in the set, the predicate succeeds.
+        -- Otherwise, it fails.
+        if allVals
+          then guard (HashSet.member vals setOfVals)
+          -- If qas aren't all values, we can't use the set and must fallback to the default behavior.
+          -- This is because in this case the variables will be unified with the values, so it's not just
+          -- a guard.
+          else compilePredDefault rules arg
     else compilePredDefault rules
   where
-
     -- A fact is a rule that has no body and matches directly on values
     isFact :: Rule a -> Bool
-    isFact rule = null (ruleBody rule) && all (not . termIsVar) (litTerms $ ruleLit rule)
+    isFact rule = null (ruleBody rule) && all termIsVal (litTerms $ ruleLit rule)
 
     ruleBody :: Rule a -> [BodyLit a]
     ruleBody  (Rule _lit body) = body
@@ -315,9 +320,9 @@ compilePred rules =
     termVal (Val v) = Just v
     termVal (Var _) = Nothing
 
-    termIsVar :: Term a -> Bool
-    termIsVar (Var _) = True
-    termIsVar _ = False
+    termIsVal :: Term a -> Bool
+    termIsVal (Val _) = True
+    termIsVal (Var _) = False
 
 -- | Turn a list of 'Rule's into a map from their names to code that executes them.
 --


### PR DESCRIPTION
Results:
- Significant improvements on benchmarks with lots of rules.
- No regression on other benchmarks

Using `Vector`
```
Benchmark       bench-master  bench-vector    
clique/10       0.322e-3      0.039e-3 -87.94%
clique/25       2.201e-3      0.191e-3 -91.34%
clique/40       0.571e-2      0.051e-2 -91.01%
clique/5        0.910e-4      0.199e-4 -78.17%
line/10         0.369e-3      0.266e-3 -28.06%
line/25         3.156e-3      1.798e-3 -43.03%
line/40         1.056e-2      0.562e-2 -46.80%
line/5          0.883e-4      0.785e-4 -11.15%
loop/100        2.032e-3      1.381e-3 -32.03%
loop/1000       0.877e-1      0.842e-1  -3.93%
loop/50         0.505e-3      0.469e-3  -7.13%
loop/500        2.347e-2      2.144e-2  -8.66%
parse/100       1.269e-2      1.285e-2  +1.24%
parse/1000      1.327e-1      1.325e-1  -0.15%
parse/50        0.604e-2      0.602e-2  -0.33%
parse/500       0.662e-1      0.679e-1  +2.62%
tight/100       0.757e-3      0.729e-3  -3.73%
tight/1000      0.775e-1      0.721e-1  -6.89%
tight/50        2.109e-4      2.075e-4  -1.59%
tight/500       1.699e-2      1.655e-2  -2.61%
Geometric mean  0.358e-2      0.208e-2 -41.85%
```

Forcing the `Vector` in `compilePred` using `force`:
```
Benchmark       bench-master  bench-vector-strict
clique/10       0.322e-3      0.043e-3 -86.57%   
clique/25       2.201e-3      0.238e-3 -89.21%   
clique/40       0.571e-2      0.098e-2 -82.81%   
clique/5        0.910e-4      0.232e-4 -74.54%   
line/10         0.369e-3      0.267e-3 -27.58%   
line/25         3.156e-3      1.858e-3 -41.14%   
line/40         1.056e-2      0.583e-2 -44.83%   
line/5          0.883e-4      0.804e-4  -9.00%   
loop/100        2.032e-3      1.394e-3 -31.43%   
loop/1000       0.877e-1      0.852e-1  -2.82%   
loop/50         0.505e-3      0.470e-3  -6.93%   
loop/500        2.347e-2      2.140e-2  -8.82%   
parse/100       1.269e-2      1.286e-2  +1.30%   
parse/1000      1.327e-1      1.349e-1  +1.68%   
parse/50        0.604e-2      0.619e-2  +2.55%   
parse/500       0.662e-1      0.693e-1  +4.81%   
tight/100       0.757e-3      0.731e-3  -3.51%   
tight/1000      0.775e-1      0.736e-1  -5.01%   
tight/50        2.109e-4      2.076e-4  -1.54%   
tight/500       1.699e-2      1.700e-2  +0.03%   
Geometric mean  0.358e-2      0.223e-2 -37.73% 
```

Using `Lists`
```
Benchmark       bench-master  bench-list      
clique/10       0.322e-3      0.039e-3 -87.86%
clique/25       2.201e-3      0.192e-3 -91.29%
clique/40       0.571e-2      0.060e-2 -89.51%
clique/5        0.910e-4      0.200e-4 -78.05%
line/10         0.369e-3      0.275e-3 -25.63%
line/25         3.156e-3      1.974e-3 -37.46%
line/40         1.056e-2      0.580e-2 -45.14%
line/5          0.883e-4      0.781e-4 -11.57%
loop/100        2.032e-3      1.467e-3 -27.83%
loop/1000       0.877e-1      0.868e-1  -0.97%
loop/50         0.505e-3      0.480e-3  -4.91%
loop/500        2.347e-2      2.437e-2  +3.84%
parse/100       1.269e-2      1.291e-2  +1.66%
parse/1000      1.327e-1      1.355e-1  +2.13%
parse/50        0.604e-2      0.616e-2  +1.94%
parse/500       0.662e-1      0.713e-1  +7.71%
tight/100       0.757e-3      0.735e-3  -2.88%
tight/1000      0.775e-1      0.707e-1  -8.71%
tight/50        2.109e-4      2.084e-4  -1.19%
tight/500       1.699e-2      1.651e-2  -2.86%
Geometric mean  0.358e-2      0.215e-2 -39.91%
```

Using hashset:
```
Benchmark       bench-master  bench-hashset   
clique/10       0.322e-3      0.048e-3 -84.95%
clique/25       2.201e-3      0.297e-3 -86.52%
clique/40       0.571e-2      0.157e-2 -72.58%
clique/5        0.910e-4      0.214e-4 -76.45%
line/10         0.369e-3      0.259e-3 -29.82%
line/25         3.156e-3      1.776e-3 -43.75%
line/40         1.056e-2      0.554e-2 -47.56%
line/5          0.883e-4      0.769e-4 -12.93%
loop/100        2.032e-3      1.345e-3 -33.83%
loop/1000       0.877e-1      0.819e-1  -6.53%
loop/50         0.505e-3      0.456e-3  -9.66%
loop/500        2.347e-2      2.057e-2 -12.35%
parse/100       1.269e-2      1.230e-2  -3.08%
parse/1000      1.327e-1      1.327e-1  +0.04%
parse/50        0.604e-2      0.619e-2  +2.52%
parse/500       0.662e-1      0.663e-1  +0.29%
tight/100       0.757e-3      0.708e-3  -6.45%
tight/1000      0.775e-1      0.698e-1  -9.84%
tight/50        2.109e-4      2.004e-4  -4.96%
tight/500       1.699e-2      1.648e-2  -3.03%
Geometric mean  0.358e-2      0.225e-2 -37.25%
```

Data:
[bench-hashset.csv](https://github.com/Simspace/avaleryar/files/8142472/bench-hashset.csv)
[bench-list.csv](https://github.com/Simspace/avaleryar/files/8142473/bench-list.csv)
[bench-master.csv](https://github.com/Simspace/avaleryar/files/8142474/bench-master.csv)
[bench-vector-strict.csv](https://github.com/Simspace/avaleryar/files/8142475/bench-vector-strict.csv)
[bench-vector.csv](https://github.com/Simspace/avaleryar/files/8142476/bench-vector.csv)

