### PR TITLE
Represent every values as text

### DIFF
--- a/core/src/Language/Avaleryar/Syntax.hs
+++ b/core/src/Language/Avaleryar/Syntax.hs
@@ -6,11 +6,13 @@
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE PolyKinds                  #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeSynonymInstances       #-}
+{-# LANGUAGE ViewPatterns               #-}
 
 {-|
 
@@ -59,12 +61,35 @@ import           GHC.Generics                 (Generic)
 import           Text.Megaparsec              (SourcePos(..), pos1, unPos)
 import           Text.PrettyPrint.Leijen.Text
     (Doc, Pretty(..), brackets, colon, dot, empty, group, hsep, line, nest, parens, punctuate, space, vsep)
+import           Text.Read (readMaybe)
 
-data Value
-  = I Int
-  | T Text
-  | B Bool
+newtype Value = T Text
     deriving (Eq, Ord, Read, Show, Generic)
+
+{-# COMPLETE I, B, T #-}
+pattern I :: Int -> Value
+pattern I i <- T (readMaybe . T.unpack -> Just i) where
+  I i = T . T.pack $ show i
+
+pattern B :: Bool -> Value
+pattern B b <- T (textToBool -> Just b) where
+  B b = T (if b then "#t" else "#f")
+
+textToBool :: Text -> Maybe Bool
+textToBool "#t" = Just True
+textToBool "#f" = Just False
+textToBool _    = Nothing
+
+-- COMPLETE Pragma is necessary because the exhausiveness checker doesn't work at all with pattern synonyms.
+-- See https://gitlab.haskell.org/ghc/ghc/-/wikis/pattern-synonyms/complete-sigs
+-- pattern IpAddr :: ToFromWords word => word -> word -> word -> word -> IpAddr word
+-- pattern IpAddr w1 w2 w3 w4 <- IpAddrInternal (toWords -> (w1, w2, w3, w4)) where
+--   IpAddr w1 w2 w3 w4 = IpAddrInternal $ fromWords w1 w2 w3 w4
+-- pattern Smarter{ nonneg } <- Pos nonneg  where
+--   Smarter x = if x >= 0 then (Pos x) else (Neg x)
+-- pattern Smarter{ nonneg } <- Pos nonneg  where
+--   Smarter x | x >= 0    = (Pos x)
+--             | otherwise = (Neg x)
 
 instance NFData Value
 instance Hashable Value
@@ -73,8 +98,6 @@ instance IsString Value where
   fromString = T . fromString
 
 instance Pretty Value where
-  pretty (I n) = pretty n
-  pretty (B b) = if b then "#t" else "#f"
   pretty (T t) = if T.any isSpace t
                  then pretty (show t) -- want the quotes/escaping
                  else pretty t        -- display as a symbol
@@ -267,7 +290,6 @@ instance Valuable Value where
 instance Valuable Text where
   toValue = T
   fromValue (T a) = Just a
-  fromValue _     = Nothing
 
 instance Valuable Int  where
   toValue = I


### PR DESCRIPTION
Results:

Before:
```
```

Now:
```
benchmarking clique/5  
time                 86.66 μs   (86.54 μs .. 86.79 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 86.97 μs   (86.84 μs .. 87.15 μs)
std dev              502.2 ns   (395.5 ns .. 642.6 ns)
                       
benchmarking clique/10 
time                 318.3 μs   (317.7 μs .. 318.8 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 318.3 μs   (317.9 μs .. 318.7 μs)
std dev              1.275 μs   (1.091 μs .. 1.568 μs)
                       
benchmarking clique/25 
time                 2.183 ms   (2.155 ms .. 2.215 ms)
                     0.998 R²   (0.996 R² .. 1.000 R²)
mean                 2.174 ms   (2.158 ms .. 2.215 ms)
std dev              85.12 μs   (29.05 μs .. 156.3 μs)
variance introduced by outliers: 24% (moderately inflated)
                       
benchmarking clique/40 
time                 5.467 ms   (5.407 ms .. 5.535 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 5.399 ms   (5.377 ms .. 5.428 ms)
std dev              80.40 μs   (60.65 μs .. 101.5 μs)
                       
benchmarking line/5    
time                 85.57 μs   (85.47 μs .. 85.68 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 85.62 μs   (85.54 μs .. 85.72 μs)
std dev              305.2 ns   (247.2 ns .. 377.1 ns)
                       
benchmarking line/10   
time                 354.1 μs   (353.7 μs .. 354.6 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 354.1 μs   (353.7 μs .. 354.5 μs)
std dev              1.286 μs   (1.060 μs .. 1.688 μs)
                       
benchmarking line/25   
time                 2.987 ms   (2.974 ms .. 3.005 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 2.976 ms   (2.972 ms .. 2.986 ms)
std dev              22.72 μs   (14.04 μs .. 41.08 μs)
                       
benchmarking line/40   
time                 10.14 ms   (9.999 ms .. 10.23 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 9.950 ms   (9.917 ms .. 10.01 ms)
std dev              118.9 μs   (83.44 μs .. 150.1 μs)
                       
benchmarking loop/50   
time                 470.3 μs   (462.8 μs .. 476.5 μs)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 460.4 μs   (458.1 μs .. 464.3 μs)
std dev              10.18 μs   (6.753 μs .. 17.01 μs)
variance introduced by outliers: 13% (moderately inflated)
                       
benchmarking loop/100  
time                 1.334 ms   (1.327 ms .. 1.340 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.339 ms   (1.337 ms .. 1.342 ms)
std dev              9.650 μs   (7.881 μs .. 12.18 μs)
                       
benchmarking loop/500  
time                 20.16 ms   (20.02 ms .. 20.33 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 20.10 ms   (20.03 ms .. 20.18 ms)
std dev              172.6 μs   (126.2 μs .. 238.3 μs)
                       
benchmarking loop/1000 
time                 79.66 ms   (78.37 ms .. 83.24 ms)
                     0.997 R²   (0.990 R² .. 1.000 R²)
mean                 79.51 ms   (78.79 ms .. 81.74 ms)
std dev              1.859 ms   (487.7 μs .. 3.167 ms)
                       
benchmarking tight/50  
time                 186.1 μs   (185.7 μs .. 186.8 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 187.0 μs   (186.4 μs .. 188.0 μs)
std dev              2.400 μs   (1.341 μs .. 4.237 μs)
                       
benchmarking tight/100 
time                 675.2 μs   (673.7 μs .. 676.7 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 677.1 μs   (675.8 μs .. 678.7 μs)
std dev              5.148 μs   (4.071 μs .. 7.105 μs)
                       
benchmarking tight/500 
time                 15.51 ms   (15.37 ms .. 15.63 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 15.73 ms   (15.60 ms .. 16.13 ms)
std dev              508.2 μs   (152.4 μs .. 992.6 μs)
variance introduced by outliers: 12% (moderately inflated)
                       
benchmarking tight/1000
time                 67.31 ms   (66.96 ms .. 67.74 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 67.53 ms   (67.23 ms .. 68.53 ms)
std dev              839.8 μs   (277.8 μs .. 1.430 ms)
                       
benchmarking parse/50  
time                 6.063 ms   (6.038 ms .. 6.086 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 6.055 ms   (6.036 ms .. 6.089 ms)
std dev              72.71 μs   (51.55 μs .. 114.3 μs)
                       
benchmarking parse/100 
time                 12.05 ms   (11.97 ms .. 12.11 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 12.01 ms   (11.97 ms .. 12.04 ms)
std dev              91.99 μs   (77.59 μs .. 118.5 μs)
                       
benchmarking parse/500 
time                 66.37 ms   (66.01 ms .. 66.71 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 66.79 ms   (66.57 ms .. 67.39 ms)
std dev              609.9 μs   (265.2 μs .. 1.038 ms)
                       
benchmarking parse/1000
time                 137.4 ms   (134.2 ms .. 140.6 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 135.1 ms   (134.0 ms .. 136.5 ms)
std dev              1.907 ms   (1.253 ms .. 3.004 ms)
variance introduced by outliers: 11% (moderately inflated)
```

With https://github.com/Simspace/avaleryar/pull/22:
```
```