### PR TITLE
Add missing INLINE pragmas in FBackTrackT

### DIFF
--- a/core/src/Control/Monad/FBackTrackT.hs
+++ b/core/src/Control/Monad/FBackTrackT.hs
@@ -49,7 +49,7 @@ instance Monad m => Applicative (Stream m) where
   pure = return
   {-# INLINE pure #-}
   (<*>) = ap
-  {-# INLINE2 (<*>) #-}
+  {-# INLINE (<*>) #-}
 
 instance Monad m => Monad (Stream m) where
   return = Stream . return . One


### PR DESCRIPTION
Results, with `-O2`:

```
Benchmark       bench-master  bench-inline    
clique/10       0.322e-3      0.138e-3 -57.04%
clique/25       2.201e-3      1.040e-3 -52.75%
clique/40       0.571e-2      0.269e-2 -52.88%
clique/5        0.910e-4      0.419e-4 -53.98%
line/10         0.369e-3      0.150e-3 -59.37%
line/25         3.156e-3      1.012e-3 -67.93%
line/40         1.056e-2      0.291e-2 -72.46%
line/5          0.883e-4      0.411e-4 -53.47%
loop/100        2.032e-3      0.538e-3 -73.52%
loop/1000       0.877e-1      0.194e-1 -77.87%
loop/50         0.505e-3      0.211e-3 -58.09%
loop/500        2.347e-2      0.583e-2 -75.18%
parse/100       1.269e-2      1.240e-2  -2.33%
parse/1000      1.327e-1      1.354e-1  +2.06%
parse/50        0.604e-2      0.609e-2  +0.88%
parse/500       0.662e-1      0.665e-1  +0.60%
tight/100       0.757e-3      0.159e-3 -78.98%
tight/1000      0.775e-1      0.111e-1 -85.68%
tight/50        2.109e-4      0.555e-4 -73.68%
tight/500       1.699e-2      0.285e-2 -83.23%
Geometric mean  0.358e-2      0.139e-2 -61.19%
```

[bench-master.csv](https://github.com/Simspace/avaleryar/files/8142516/bench-master.csv)
[bench-inline.csv](https://github.com/Simspace/avaleryar/files/8142514/bench-inline.csv)